### PR TITLE
Support for Minecraft 1.20.6 and Beyond 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <repositories>
         <repository>
             <id>purpur</id>
-            <url>https://repo.pl3x.net/</url>
+            <url>https://repo.purpurmc.org/snapshots</url>
         </repository>
         <repository>
             <id>sonatype</id>
@@ -82,15 +82,20 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+        <repository>
+            <id>maven_central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>net.pl3x.purpur</groupId>
+            <groupId>org.purpurmc.purpur</groupId>
             <artifactId>purpur-api</artifactId>
-            <version>1.16.2-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -102,19 +107,19 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
+            <version>3.0.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.6</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.zrips</groupId>
-            <artifactId>cmi-api</artifactId>
-            <version>7.6.2.0</version>
+            <groupId>CMI-API</groupId>
+            <artifactId>CMI-API</artifactId>
+            <version>9.7.0.8</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/luffbox/smoothsleep/PlayerData.java
+++ b/src/main/java/com/luffbox/smoothsleep/PlayerData.java
@@ -250,7 +250,7 @@ public class PlayerData implements Purgeable {
 	public void setSleepTicks(long ticks) {
 		try {
 			Object nmsPlr = ReflectUtil.invokeMethod(plr, "getHandle");
-			ReflectUtil.setValue(nmsPlr, false, "sleepTicks", (int) ticks);
+			ReflectUtil.setValue(nmsPlr, false, "sleepCounter", (int) ticks);
 		} catch (Exception e) { e.printStackTrace(); }
 	}
 }

--- a/src/main/java/com/luffbox/smoothsleep/PlayerData.java
+++ b/src/main/java/com/luffbox/smoothsleep/PlayerData.java
@@ -250,7 +250,7 @@ public class PlayerData implements Purgeable {
 	public void setSleepTicks(long ticks) {
 		try {
 			Object nmsPlr = ReflectUtil.invokeMethod(plr, "getHandle");
-			ReflectUtil.setValue(nmsPlr, false, "sleepCounter", (int) ticks);
+			ReflectUtil.setValue(nmsPlr, true, "sleepCounter", (int) ticks);
 		} catch (Exception e) { e.printStackTrace(); }
 	}
 }

--- a/src/main/java/com/luffbox/smoothsleep/lib/ConfigHelper.java
+++ b/src/main/java/com/luffbox/smoothsleep/lib/ConfigHelper.java
@@ -37,13 +37,13 @@ public class ConfigHelper {
 	private final ConfigHelper conf;
 	public Map<World, WorldSettings> worlds = new HashMap<>();
 
-	public static Set<PotionEffectType> negativeEffects = Stream.of(BLINDNESS, CONFUSION, HARM, HUNGER, LEVITATION,
-			POISON, SLOW, SLOW_DIGGING, UNLUCK, WEAKNESS, WITHER, UNLUCK).collect(Collectors.toSet());
-	public static Set<PotionEffectType> positiveEffects = Stream.of(ABSORPTION, DAMAGE_RESISTANCE, FAST_DIGGING,
-			FIRE_RESISTANCE, GLOWING, HEAL, HEALTH_BOOST, INCREASE_DAMAGE, INVISIBILITY, JUMP, NIGHT_VISION,
+	public static Set<PotionEffectType> negativeEffects = Stream.of(BLINDNESS, NAUSEA, INSTANT_DAMAGE, HUNGER, LEVITATION,
+			POISON, SLOWNESS, MINING_FATIGUE, UNLUCK, WEAKNESS, WITHER, UNLUCK).collect(Collectors.toSet());
+	public static Set<PotionEffectType> positiveEffects = Stream.of(ABSORPTION, RESISTANCE, HASTE,
+			FIRE_RESISTANCE, GLOWING, INSTANT_HEALTH, HEALTH_BOOST, STRENGTH, INVISIBILITY, JUMP_BOOST, NIGHT_VISION,
 			REGENERATION, SATURATION, SPEED, WATER_BREATHING, LUCK).collect(Collectors.toSet());
-	public static Set<Particle> requiresData = Stream.of(REDSTONE, BLOCK_CRACK, BLOCK_DUST, FALLING_DUST, ITEM_CRACK,
-			SPELL_MOB, SPELL_MOB_AMBIENT).collect(Collectors.toSet());
+	public static Set<Particle> requiresData = Stream.of(DUST, BLOCK, DUST_PILLAR, FALLING_DUST, ITEM,
+			WITCH, BLOCK_MARKER, SHRIEK, SCULK_CHARGE, VIBRATION, DUST_COLOR_TRANSITION, ENTITY_EFFECT).collect(Collectors.toSet());
 	public static boolean firstRun;
 
 	private static String validBarColors, validBarStyles, validParticlePatternTypes;

--- a/src/main/java/com/luffbox/smoothsleep/lib/MiscUtils.java
+++ b/src/main/java/com/luffbox/smoothsleep/lib/MiscUtils.java
@@ -1,7 +1,7 @@
 package com.luffbox.smoothsleep.lib;
 
 import com.luffbox.smoothsleep.SmoothSleep;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;

--- a/src/main/java/com/luffbox/smoothsleep/lib/ReflectUtil.java
+++ b/src/main/java/com/luffbox/smoothsleep/lib/ReflectUtil.java
@@ -97,9 +97,20 @@ public class ReflectUtil {
 	 * @throws SecurityException If the desired field cannot be made accessible
 	 */
 	public static Field getField(Class<?> clazz, boolean declared, String fieldName) throws NoSuchFieldException, SecurityException {
-		Field field = declared ? clazz.getDeclaredField(fieldName) : clazz.getField(fieldName);
-		field.setAccessible(true);
-		return field;
+		if (!declared) {
+			Field field = clazz.getField(fieldName);
+			field.setAccessible(true);
+			return field;
+		}
+
+		for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+			try {
+				Field field = current.getDeclaredField(fieldName);
+				field.setAccessible(true);
+				return field;
+			} catch (NoSuchFieldException ignored) {}
+		}
+		throw new NoSuchFieldException(fieldName);
 	}
 
 	/**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,7 +19,7 @@ worlds:
     heal-slept-villagers: true
     morning-sound: 'ENTITY_PLAYER_LEVELUP'
     morning-particle-options:
-      particle: 'VILLAGER_HAPPY'
+      particle: 'HAPPY_VILLAGER'
       amount: 20
       radius: 0.5
       enabled: true


### PR DESCRIPTION
This PR adds support for Minecraft 1.20.6 and 26.2. 

Unfortunately, after so many versions, SmoothSleep finally broke due to breaking changes in the Bukkit API. This PR **does not** maintain backwards compatibility, it only supports 1.20.5 onwards.

Here's a working build: https://github.com/LOOHP/SmoothSleep/releases/tag/MC-26.2